### PR TITLE
CMake: Fall back to unknown version when Hg repo is missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,30 +17,46 @@ OPTION(XNA4_VERTEXTEXTURE "Build MojoShader with XNA4 vertex texturing behavior"
 
 INCLUDE_DIRECTORIES(.)
 
+# If Mercurial is installed and we are in a mercurial repository, include the rev# and changeset as version information.
 FIND_PROGRAM(HG hg DOC "Path to hg command line app: http://www.selenic.com/mercurial/")
-IF(NOT HG OR MOJOSHADER_NO_VERSION_INCLUDE)
+IF(NOT HG)
     MESSAGE(STATUS "Mercurial (hg) not found. You can go on, but version info will be wrong.")
     SET(MOJOSHADER_VERSION -1)
     SET(MOJOSHADER_CHANGESET "???")
-ELSE(NOT HG OR MOJOSHADER_NO_VERSION_INCLUDE)
+ELSE(NOT HG)
     MARK_AS_ADVANCED(HG)
+
+    # See if we are in an hg repository.
     EXECUTE_PROCESS(
-        COMMAND hg tip --template {rev}
+        COMMAND hg root
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
         RESULT_VARIABLE HGVERSION_RC
-        OUTPUT_VARIABLE MOJOSHADER_VERSION
         ERROR_QUIET
-        OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-    EXECUTE_PROCESS(
-        COMMAND hg tip --template hg-{rev}:{node|short}
-        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-        RESULT_VARIABLE HGVERSION_RC
-        OUTPUT_VARIABLE MOJOSHADER_CHANGESET
-        ERROR_QUIET
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-ENDIF(NOT HG OR MOJOSHADER_NO_VERSION_INCLUDE)
+    IF(NOT HGVERSION_RC EQUAL 0)
+        MESSAGE(STATUS "Mercurial (hg) repository not found. You can go on, but version info will be wrong.")
+        SET(MOJOSHADER_VERSION -1)
+        SET(MOJOSHADER_CHANGESET "???")
+    ELSE(NOT HGVERSION_RC EQUAL 0)
+        # Query the rev and changeset.
+        EXECUTE_PROCESS(
+            COMMAND hg tip --template {rev}
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+            RESULT_VARIABLE HGVERSION_RC
+            OUTPUT_VARIABLE MOJOSHADER_VERSION
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        EXECUTE_PROCESS(
+            COMMAND hg tip --template hg-{rev}:{node|short}
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+            RESULT_VARIABLE HGVERSION_RC
+            OUTPUT_VARIABLE MOJOSHADER_CHANGESET
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    ENDIF(NOT HGVERSION_RC EQUAL 0)
+ENDIF(NOT HG)
 
 WRITE_FILE(
     "${CMAKE_CURRENT_SOURCE_DIR}/mojoshader_version.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,11 @@ OPTION(XNA4_VERTEXTEXTURE "Build MojoShader with XNA4 vertex texturing behavior"
 INCLUDE_DIRECTORIES(.)
 
 FIND_PROGRAM(HG hg DOC "Path to hg command line app: http://www.selenic.com/mercurial/")
-IF(NOT HG)
+IF(NOT HG OR MOJOSHADER_NO_VERSION_INCLUDE)
     MESSAGE(STATUS "Mercurial (hg) not found. You can go on, but version info will be wrong.")
     SET(MOJOSHADER_VERSION -1)
     SET(MOJOSHADER_CHANGESET "???")
-ELSE(NOT HG)
+ELSE(NOT HG OR MOJOSHADER_NO_VERSION_INCLUDE)
     MARK_AS_ADVANCED(HG)
     EXECUTE_PROCESS(
         COMMAND hg tip --template {rev}
@@ -40,7 +40,7 @@ ELSE(NOT HG)
         ERROR_QUIET
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-ENDIF(NOT HG)
+ENDIF(NOT HG OR MOJOSHADER_NO_VERSION_INCLUDE)
 
 WRITE_FILE(
     "${CMAKE_CURRENT_SOURCE_DIR}/mojoshader_version.h"


### PR DESCRIPTION
The readme says that if you don't have cmake you can pass MOJOSHADER_NO_VERSION_INCLUDE, however there is a case where you may be working with a non-hg cloned repository (but still have hg installed and using cmake).  If hg is not detected it uses -1, and so it seems reasonable that if you want to bypass the version generation, it should use the same -1 value if you explicitly pass -DMOJOSHADER_NO_VERSION_INCLUDE.