### PR TITLE
Preliminary implementation of texldl for explicit LOD selection

### DIFF
--- a/profiles/mojoshader_profile_glsl.c
+++ b/profiles/mojoshader_profile_glsl.c
@@ -1685,7 +1685,8 @@ void emit_GLSL_TEXLDD_setup(Context *ctx)
 
 static void glsl_texld(Context *ctx, const int texldd, const int texldl)
 {
-    emit_GLSL_TEXLDD_setup(ctx);
+    if (texldd || texldl)
+        emit_GLSL_TEXLDD_setup(ctx);
 
     if (!shader_version_atleast(ctx, 1, 4))
     {


### PR DESCRIPTION
a GL extension was added in 2009 (and in GLES3 given that GLES2 was missing this) that allows explicitly selecting LODs in fragment shaders instead of just in vertex shaders. This PR enables that so texldl works correctly (instead of just picking the default lod as before).
In my basic testing with 2D compute shaders this fixes a bunch of weird issues, but I have no test case for 3D.
This code confuses me a lot so I'm not sure it's right.