### PR TITLE
MSVC compile fix

### DIFF
--- a/profiles/mojoshader_profile_glsl.c
+++ b/profiles/mojoshader_profile_glsl.c
@@ -957,12 +957,7 @@ void emit_GLSL_attribute(Context *ctx, RegisterType regtype, int regnum,
                     if (support_glsles(ctx))
                         break; // GLSL ES does not have gl_FogFragCoord
 #endif
-#if SUPPORT_PROFILE_GLSLES
-                    const int skipFogFragCoord = support_glsles(ctx) || (index > 0);
-#else
-                    const int skipFogFragCoord = (index > 0);
-#endif
-                    if (!skipFogFragCoord)
+                    if (index == 0)
                     {
                         usage_str = "gl_FogFragCoord";
                     } // if


### PR DESCRIPTION
MojoShader cannot be compiled with MSVC due to a [variable initialization inside of a switch statement](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2360). This patch fixes the issue and also removes a redundant check. (If the code reaches this point, we can be sure `support_glsles(ctx)` is false, otherwise we would have already broken out of the switch.)