### PR TITLE
Add proper support for gl_PointCoord and [[point_coord]]

### DIFF
--- a/mojoshader.c
+++ b/mojoshader.c
@@ -3469,6 +3469,7 @@ static MOJOSHADER_parseData *build_parsedata(Context *ctx)
     retval->malloc = (ctx->malloc == MOJOSHADER_internal_malloc) ? NULL : ctx->malloc;
     retval->free = (ctx->free == MOJOSHADER_internal_free) ? NULL : ctx->free;
     retval->malloc_data = ctx->malloc_data;
+    retval->uses_pointsize = ctx->uses_pointsize;
 
     return retval;
 } // build_parsedata

--- a/mojoshader.h
+++ b/mojoshader.h
@@ -650,7 +650,7 @@ typedef struct MOJOSHADER_parseData
     MOJOSHADER_preshader *preshader;
 
     /*
-     * A flag to indicate if the shader uses a POINTSIZE attribute.
+     * A flag that indicates if the shader has a POINTSIZE attribute.
      */
     int uses_pointsize;
 

--- a/mojoshader.h
+++ b/mojoshader.h
@@ -650,6 +650,11 @@ typedef struct MOJOSHADER_parseData
     MOJOSHADER_preshader *preshader;
 
     /*
+     * A flag to indicate if the shader uses a POINTSIZE attribute.
+     */
+    int uses_pointsize;
+
+    /*
      * This is the malloc implementation you passed to MOJOSHADER_parse().
      */
     MOJOSHADER_malloc malloc;

--- a/mojoshader_effects.c
+++ b/mojoshader_effects.c
@@ -838,23 +838,21 @@ static void readlargeobjects(const uint32 numlargeobjects,
 static void texcoord_to_pointcoord(MOJOSHADER_effect* effect)
 {
     int i;
-    int glsl, msl;
     int uses_pointsize;
     char* texcoord0, *replacement;
 
-    // This function uses profile-dependent behavior
-    glsl = strcmp(effect->profile, MOJOSHADER_PROFILE_GLSL) == 0 ||
-        strcmp(effect->profile, MOJOSHADER_PROFILE_GLSL120) == 0;
-    msl = strcmp(effect->profile, MOJOSHADER_PROFILE_METAL) == 0;
+    int glsl = strcmp(effect->profile, MOJOSHADER_PROFILE_GLSL) == 0 ||
+            strcmp(effect->profile, MOJOSHADER_PROFILE_GLSL120) == 0;
+    int msl = strcmp(effect->profile, MOJOSHADER_PROFILE_METAL) == 0;
 
     if (glsl)
     {
-        texcoord0 = "gl_TexCoord[0]";
+        texcoord0   = "gl_TexCoord[0]";
         replacement = "gl_PointCoord ";
     }
     else if (msl)
     {
-        texcoord0 = "[[user(texcoord0)]]";
+        texcoord0   = "[[user(texcoord0)]]";
         replacement = "[[  point_coord  ]]";
     }
     else
@@ -902,19 +900,19 @@ static void texcoord_to_pointcoord(MOJOSHADER_effect* effect)
                     if (msl)
                     {
                         /* [[point_coord]] is a float2, not a float4.
-                         * Go backwards so we can splice in the '2'.
+                         * Go backwards and splice in the '2'.
                          */
                         int spaces = 0;
                         while (spaces < 2)
                             if (*(c--) == ' ')
                                 spaces++;
                         memcpy((void*)c, "2", sizeof(char));
-                    }
-                }
+                    } // if
+                } // if
             } // if
         } // for
     } // if
-}
+} // texcoord_to_pointcoord
 
 MOJOSHADER_effect *MOJOSHADER_parseEffect(const char *profile,
                                           const unsigned char *buf,


### PR DESCRIPTION
Tested successfully with Flotilla on macOS OpenGL and Metal.

This was actually pretty straightforward to implement, although there is a catch: the current implementation runs the risk of nuking actual uses of `TEXCOORD0`. If an effect contains _any_ vertex shader with a `POINTSIZE` attribute, it will search+replace "gl_TexCoord[0]" -> "gl_PointCoord" for _all_ fragment shaders in the effect. This works for Flotilla, but I'm nervous it might screw with other games that use point drawing.

One alternative would be to go through each pass in each technique in each effect and only perform the switcheroo on pixel shaders whose corresponding vertex shader has the point size attribute. But that gets complicated pretty quickly and leads to weird edge cases... I'll experiment with it more when I get the time.