### PR TITLE
Metal: Set ctx to NULL after free

### DIFF
--- a/mojoshader_metal.c
+++ b/mojoshader_metal.c
@@ -396,6 +396,7 @@ void MOJOSHADER_mtlDestroyContext(void)
 {
     ctx->free_fn(ctx->buffersInUse, ctx->malloc_data);
     ctx->free_fn(ctx, ctx->malloc_data);
+    ctx = NULL;
 } // MOJOSHADER_mtlDestroyContext
 
 void *MOJOSHADER_mtlCompileLibrary(MOJOSHADER_effect *effect)


### PR DESCRIPTION
This fixes a bug where FNA games that recreate their GraphicsDevice could trigger the assertion on line 345.