### PR TITLE
Store pixel shader input attributes, add type data to vertex attributes

### DIFF
--- a/mojoshader.c
+++ b/mojoshader.c
@@ -3240,10 +3240,6 @@ static MOJOSHADER_attribute *build_attributes(Context *ctx, int *_count)
                 case REG_TYPE_DEPTHOUT:
                     ignore = 1;
                     break;
-                case REG_TYPE_TEXTURE:
-                case REG_TYPE_MISCTYPE:
-                    ignore = shader_is_pixel(ctx);
-                    break;
                 default:
                     ignore = 0;
                     break;

--- a/mojoshader.c
+++ b/mojoshader.c
@@ -3242,7 +3242,6 @@ static MOJOSHADER_attribute *build_attributes(Context *ctx, int *_count)
                     break;
                 case REG_TYPE_TEXTURE:
                 case REG_TYPE_MISCTYPE:
-                case REG_TYPE_INPUT:
                     ignore = shader_is_pixel(ctx);
                     break;
                 default:
@@ -3252,16 +3251,11 @@ static MOJOSHADER_attribute *build_attributes(Context *ctx, int *_count)
 
             if (!ignore)
             {
-                if (shader_is_pixel(ctx))
-                    fail(ctx, "BUG: pixel shader with vertex attributes");
-                else
-                {
-                    wptr->usage = item->usage;
-                    wptr->index = item->index;
-                    wptr->name = alloc_varname(ctx, item);
-                    wptr++;
-                    count++;
-                } // else
+                wptr->usage = item->usage;
+                wptr->index = item->index;
+                wptr->name = alloc_varname(ctx, item);
+                wptr++;
+                count++;
             } // if
 
             item = item->next;
@@ -3516,6 +3510,7 @@ static void process_definitions(Context *ctx)
         RegisterList *next = item->next;
         const RegisterType regtype = item->regtype;
         const int regnum = item->regnum;
+        MOJOSHADER_usage usage;
 
         if (!get_defined_register(ctx, regtype, regnum))
         {
@@ -3537,9 +3532,27 @@ static void process_definitions(Context *ctx)
 
                     // Apparently this is an attribute that wasn't DCL'd.
                     //  Add it to the attribute list; deal with it later.
-                    // !!! FIXME: we should use something other than UNKNOWN here.
-                    add_attribute_register(ctx, regtype, regnum,
-                                           MOJOSHADER_USAGE_UNKNOWN, 0, 0xF, 0);
+                    if (regtype == REG_TYPE_RASTOUT)
+                    {
+                        if ((RastOutType) regnum == RASTOUT_TYPE_POSITION)
+                            usage = MOJOSHADER_USAGE_POSITION;
+                        else if ((RastOutType) regnum == RASTOUT_TYPE_FOG)
+                            usage = MOJOSHADER_USAGE_FOG;
+                        else if ((RastOutType) regnum==RASTOUT_TYPE_POINT_SIZE)
+                            usage = MOJOSHADER_USAGE_POINTSIZE;
+                    } // if
+                    else if (regtype == REG_TYPE_ATTROUT ||
+                             regtype == REG_TYPE_COLOROUT)
+                    {
+                        usage = MOJOSHADER_USAGE_COLOR;
+                    } // else if
+                    else if (regtype == REG_TYPE_TEXCRDOUT)
+                        usage = MOJOSHADER_USAGE_TEXCOORD;
+                    else if (regtype == REG_TYPE_DEPTHOUT)
+                        usage = MOJOSHADER_USAGE_DEPTH;
+
+                    add_attribute_register(ctx, regtype, regnum, usage,
+                                           regnum, 0xF, 0);
                     break;
 
                 case REG_TYPE_ADDRESS:


### PR DESCRIPTION
I noticed a couple issues while working on the HLSL emitter:
1) Mojoshader does not store pixel shader input elements. The `attribute_count` field of parse data for pixel shaders is always 0. This also means testparse always displays pixel shader inputs as `(none.)`.
2) Testparse always reports vertex attribute types as `<unknown>`, which isn't terribly helpful for debugging.

This patch fixes both issues.