### PR TITLE
Fixing SM1 shaders on SPIR-V after TEX* opcodes changes

### DIFF
--- a/mojoshader.c
+++ b/mojoshader.c
@@ -1737,15 +1737,6 @@ static void state_texops(Context *ctx, const char *opcode,
         add_sampler(ctx, dst->regnum, ttyp, texbem);
     } // if
 
-    add_attribute_register(ctx, REG_TYPE_TEXTURE, dst->regnum,
-                           MOJOSHADER_USAGE_TEXCOORD, dst->regnum, 0xF, 0);
-
-    // Strictly speaking, there should be a TEX opcode prior to this call that
-    //  should fill in this metadata, but I'm not sure that's required for the
-    //  shader to assemble in D3D, so we'll do this so we don't fail with a
-    //  cryptic error message even if the developer didn't do the TEX.
-    add_attribute_register(ctx, REG_TYPE_TEXTURE, src->regnum,
-                           MOJOSHADER_USAGE_TEXCOORD, src->regnum, 0xF, 0);
 } // state_texops
 
 static void state_texbem(Context *ctx, const char *opcode)

--- a/profiles/mojoshader_profile_spirv.h
+++ b/profiles/mojoshader_profile_spirv.h
@@ -211,6 +211,11 @@ typedef struct SpirvContext
         uint32 idtexbeml;
     } sampler_extras[4];
 
+    // TEX opcode in ps_1_3 and below has one implicit texcoord input attribute for each texture
+    // register. We use this array to hold SSA id of this input attribute (see emit_SPIRV_global
+    // for details).
+    uint32 id_implicit_input[4];
+
     int loop_stack_idx;
     SpirvLoopInfo loop_stack[32];
 } SpirvContext;


### PR DESCRIPTION
I ran into two problems:
1. SPIR-V emittor relies on input attributes implied by ps_1_3 (and below) TEX* opcodes, but those have been recently removed, causing SPIR-V emittor to produce invalid binaries. However, once that was fixed, I noticed that some shaders were declaring these implicit input multiple times. Which brings me to ...
2. Only TEX opcode had its implicit input attribute removed. However, other TEX* opcodes (TEXBEM, etc.) have not only been still adding theirs, they were also re-adding those from TEX.

Both problems are fixed by the PR, but it might be worth discussing problem 2. with Ryan, as I'm only guessing his intention was to remove these implicit attributes everywhere.