### PR TITLE
Fix secondary outputs in MRT shaders being discarded

### DIFF
--- a/profiles/mojoshader_profile_spirv.c
+++ b/profiles/mojoshader_profile_spirv.c
@@ -276,7 +276,7 @@ static void spv_output_attrib_location(Context *ctx, uint32 id,
 {
     SpirvPatchTable* table = &ctx->spirv.patch_table;
     push_output(ctx, &ctx->helpers);
-    spv_emit(ctx, 4, SpvOpDecorate, id, SpvDecorationLocation, 0xDEADBEEF);
+    spv_emit(ctx, 4, SpvOpDecorate, id, SpvDecorationLocation, index);
     pop_output(ctx);
     table->attrib_offsets[usage][index] = (buffer_size(ctx->helpers) >> 2) - 1;
 } // spv_output_attrib_location


### PR DESCRIPTION
For some reason mojoshader was setting the location of all attributes other than COLOR0 to garbage, so the shader's other outputs were being discarded and the secondary RTs were always black.