### PR TITLE
Fix segfault on architectures where char is unsigned

### DIFF
--- a/misc/lemon.c
+++ b/misc/lemon.c
@@ -3466,7 +3466,7 @@ void print_stack_union(
   int maxdtlength;          /* Maximum length of any ".datatype" field. */
   char *stddt;              /* Standardized name for a datatype */
   int i,j;                  /* Loop counters */
-  int hash;                 /* For hashing the name of a type */
+  unsigned int hash;        /* For hashing the name of a type */
   const char *name;         /* Name of the parser */
 
   /* Allocate and initialize types[] and allocate stddt[] */


### PR DESCRIPTION
From: Adrian Bunk

On architectures where char is unsigned, such as arm64, a signed hash
value can become negative and cause out-of-bounds access before types[0].

Resolves: #49  
Bug-Debian: https://bugs.debian.org/976553