### PR TITLE
cmake: obey CMP0026 and do not read LOCATION property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,12 +87,11 @@ ENDIF(MSVC)
 # We build lemon, then use it to generate parser C code.
 IF(COMPILER_SUPPORT)
     ADD_EXECUTABLE(lemon "misc/lemon.c")
-    GET_TARGET_PROPERTY(LEMON lemon LOCATION)
     ADD_CUSTOM_COMMAND(
         OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/mojoshader_parser_hlsl.h"
         MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/mojoshader_parser_hlsl.lemon"
         DEPENDS lemon "${CMAKE_CURRENT_SOURCE_DIR}/misc/lempar.c"
-        COMMAND "${LEMON}"
+        COMMAND lemon
         ARGS -q "-T${CMAKE_CURRENT_SOURCE_DIR}/misc/lempar.c" "${CMAKE_CURRENT_SOURCE_DIR}/mojoshader_parser_hlsl.lemon"
     )
 ENDIF(COMPILER_SUPPORT)


### PR DESCRIPTION
ADD_CUSTOM_COMMAND knows about target names. You don't need to fetch the
location yourself. Otherwise, CMake version 3.21.0 will warn this.