### PR TITLE
Build fix for alloca on *BSD

### DIFF
--- a/mojoshader_internal.h
+++ b/mojoshader_internal.h
@@ -16,7 +16,10 @@
 
 /* FIXME: These includes are needed for alloca :( */
 #include <stdlib.h>
-#ifndef __APPLE__
+#if defined(__linux__) || defined(__sun)
+#include <alloca.h>
+#endif
+#ifdef _MSC_VER
 #include <malloc.h>
 #endif
 
@@ -258,10 +261,6 @@ typedef uint32_t uint32;
 typedef int32_t int32;
 typedef int64_t int64;
 typedef uint64_t uint64;
-#endif
-
-#ifdef sun
-#include <alloca.h>
 #endif
 #endif /* MOJOSHADER_USE_SDL_STDLIB */
 


### PR DESCRIPTION
Build fix for alloca on *BSD.

For alloca() the alloca.h header should be used for ancient glibc, modern versions of glibc include alloca.h from stdlib.h anyway, and Solaris. malloc.h is not portable and is more of a Linux-ism and has been long deprecated.