### PR TITLE
Fix cos mistakenly running as acos

### DIFF
--- a/mojoshader_internal.h
+++ b/mojoshader_internal.h
@@ -54,7 +54,7 @@ typedef Uint64 uint64;
 #define asin SDL_asin
 #define atan SDL_atan
 #define atan2 SDL_atan2
-#define cos SDL_acos
+#define cos SDL_cos
 #define exp SDL_exp
 #define floor SDL_floor
 #define log SDL_log


### PR DESCRIPTION
There is a typo that causes `cos` to run `acos` code. I believe this only affects preshaders, but I'm not too familiar with how things all work. (I did notice that `cos` would work correctly if the inputs involved other shader parameters)

https://github.com/icculus/mojoshader/blob/6148aaa1b4a9069c426a66cc028287d189e122ac/mojoshader_internal.h#L52-L57

Here is a shader that shows the bug
```
float4 PixelShaderFunction(float2 coords : TEXCOORD0) : COLOR0
{
	float4 color = tex2D(uImage0, coords);
	color.a = 1;
	float xPos = (coords.x - uSourceRect.x / uImageSize0.x) * (uImageSize0.x / uSourceRect.z);
	
	if(xPos > 0.5)
	{
		color.rgb = cos(uTime) * 0.5 + 0.5; 
	}
	else
	{
		color.rgb = sin(uTime) * 0.5 + 0.5; 
	}
}
```

https://github.com/icculus/mojoshader/assets/4522492/9a068130-a63f-4f79-bbcb-95fe4c1dd1e3

As shown above, the right side, the `cos` side, jumps between values as `acos` would.

Here is the fixed code running the same shader:

https://github.com/icculus/mojoshader/assets/4522492/8a517ccb-34c4-4f4a-acce-761b819e1516

Both `cos` and `sin` now smoothly interpolate, as expected.


