### PR TITLE
SPIR-V: Remove color relocation logic for non-glspirv profiles

### DIFF
--- a/mojoshader_internal.h
+++ b/mojoshader_internal.h
@@ -789,7 +789,8 @@ typedef struct SpirvPatchTable
 } SpirvPatchTable;
 
 void MOJOSHADER_spirv_link_attributes(const MOJOSHADER_parseData *vertex,
-                                      const MOJOSHADER_parseData *pixel);
+                                      const MOJOSHADER_parseData *pixel,
+                                      int is_glspirv);
 #endif
 
 #endif  // _INCLUDE_MOJOSHADER_INTERNAL_H_

--- a/mojoshader_opengl.c
+++ b/mojoshader_opengl.c
@@ -529,7 +529,7 @@ static GLuint impl_SPIRV_LinkProgram(MOJOSHADER_glShader *vshader,
     // other shader stages to assign final uniform/attrib locations before
     // compilation.
 
-    MOJOSHADER_spirv_link_attributes(vshader->parseData, pshader->parseData);
+    MOJOSHADER_spirv_link_attributes(vshader->parseData, pshader->parseData, 1);
 
     if (vshader)
     {

--- a/mojoshader_vulkan.c
+++ b/mojoshader_vulkan.c
@@ -668,7 +668,7 @@ MOJOSHADER_vkProgram *MOJOSHADER_vkLinkProgram(MOJOSHADER_vkContext *ctx,
         return NULL;
     } // if
 
-    MOJOSHADER_spirv_link_attributes(vshader->parseData, pshader->parseData);
+    MOJOSHADER_spirv_link_attributes(vshader->parseData, pshader->parseData, 0);
     result->vertexModule = compile_shader(ctx, vshader);
     result->pixelModule = compile_shader(ctx, pshader);
     result->vertexShader = vshader;


### PR DESCRIPTION
`MOJOSHADER_spirv_link_attributes` performs some postprocessing operations on the SPIR-V content to rearrange and match up vertex output and pixel input. This is necessary for cross-stage linkage, and it works for Vulkan and OpenGL. However, when using SPIRV-Cross to transpile the emitted SPIR-V into HLSL, there are certain relocations that produce invalid HLSL. Specifically, the dedicated logic for COLOR attributes results in vertex outputs/pixel inputs with "holes" in them, which will cause link errors when compiling the HLSL.

This PR disables the COLOR attribute relocation logic on non-`glspirv` profiles. The logic was added specifically for OpenGL 4.6 SPIR-V support in the first place, so it's unnecessary on other profiles anyway. (In fact, it may be unnecessary even with `glspirv` -- all my tests seemed to run as expected with all of the color relocation disabled! But just for safety, we'll keep it for now.)