### PR TITLE
spirv: Add patch table for vertex attribute types

### DIFF
--- a/mojoshader_internal.h
+++ b/mojoshader_internal.h
@@ -787,7 +787,23 @@ typedef struct SpirvPatchTable
     uint32 tid_pvec2i;
     uint32 tid_vec2;
     uint32 tid_pvec4i;
+
+    /// Patches for TEXCOORD0 and vertex attribute types
     uint32 tid_vec4;
+    uint32 tid_ivec4;
+    uint32 tid_uvec4;
+
+    // Patches for vertex attribute types
+    uint32 tid_vec4_p;
+    uint32 tid_ivec4_p;
+    uint32 tid_uvec4_p;
+    uint32 attrib_type_offsets[MOJOSHADER_USAGE_TOTAL][16];
+    struct
+    {
+        uint32 num_loads;
+        uint32 *load_types;
+        uint32 *load_opcodes;
+    } attrib_type_load_offsets[MOJOSHADER_USAGE_TOTAL][16];
 
     // Patches for linking vertex output/pixel input
     uint32 attrib_offsets[MOJOSHADER_USAGE_TOTAL][16];


### PR DESCRIPTION
This one's for @thatcosmonaut and @TheSpydog - this should at least get the offsets for when attribs are declared and loaded:

- `attrib_type_offsets` is the word offset for the type id when the input is declared - when passing the vertex element bindings to MojoShader this is where we change it from vec3 to ivec4/uvec4 depending on the vertex format.
- `attrib_type_load_offsets` is the full list of offsets where the attrib is loaded via `SpvOpLoad`, and then either copied via `SpvOpCopyObject` or converted via either `SpvOpConvertSToF` or `SpvOpConvertUToF`.

So, for example, for a ubyte4 element, the shader runtime needs to change the value at `attrib_type_offsets[usage][index]` to `tid_uvec4_p`, and then for all loads in `attrib_type_load_offsets[usage][index]` the types will be changed to `tid_uvec4` and the opcodes will be changed to `SpvOpConvertUToF`.

Testing/Reviewing this will require modifying mojoshader_sdlgpu to export a vertex shader compilation stage, and then modifying FNA3D to make use of it. I _think_ the offsets are right, but `base_offset` may need to be updated depending on which chunk of the SPIR-V module certain offsets reside in (i.e. "do we need to add mainline_intro to the base_offset before doing the word arithmetic to finalize the load offsets").

Fixes #68