### PR TITLE
SPIR-V non-float vertex patching

### DIFF
--- a/mojoshader.h
+++ b/mojoshader.h
@@ -4098,6 +4098,12 @@ DECLSPEC void MOJOSHADER_d3d11DestroyContext(MOJOSHADER_d3d11Context *context);
 typedef struct MOJOSHADER_sdlContext MOJOSHADER_sdlContext;
 typedef struct MOJOSHADER_sdlShaderData MOJOSHADER_sdlShaderData;
 typedef struct MOJOSHADER_sdlProgram MOJOSHADER_sdlProgram;
+typedef struct MOJOSHADER_sdlVertexAttribute
+{
+    MOJOSHADER_usage usage;
+    int vertexElementFormat; /* FNA3D_VertexElementFormat */
+    int usageIndex;
+} MOJOSHADER_sdlVertexAttribute;
 
 #ifndef SDL_GPU_H
 typedef struct SDL_GpuDevice SDL_GpuDevice;
@@ -4223,11 +4229,13 @@ DECLSPEC const MOJOSHADER_parseData *MOJOSHADER_sdlGetShaderParseData(
                                                   MOJOSHADER_sdlShaderData *shader);
 
 /*
- * Link a vertex and pixel shader into a working SDL_gpu shader program.
+ * Link bound vertex and pixel shader into a working SDL_gpu shader program.
  *  (vshader) or (pshader) can NOT be NULL, unlike OpenGL.
  *
  * You can reuse shaders in various combinations across
  *  multiple programs, by relinking different pairs.
+ *
+ * Requires vertex element data for patches.
  *
  * It is illegal to give a vertex shader for (pshader) or a pixel shader
  *  for (vshader).
@@ -4237,8 +4245,8 @@ DECLSPEC const MOJOSHADER_parseData *MOJOSHADER_sdlGetShaderParseData(
  * Returns NULL on error, or a program handle on success.
  */
 DECLSPEC MOJOSHADER_sdlProgram *MOJOSHADER_sdlLinkProgram(MOJOSHADER_sdlContext *context,
-                                                          MOJOSHADER_sdlShaderData *vshader,
-                                                          MOJOSHADER_sdlShaderData *pshader);
+                                                          MOJOSHADER_sdlVertexAttribute *vertexAttributes,
+                                                          int vertexAttributeCount);
 
 /*
  * This binds the program to the active context, and does nothing particularly
@@ -4354,4 +4362,3 @@ DECLSPEC unsigned int MOJOSHADER_sdlGetSamplerSlots(MOJOSHADER_sdlShaderData *sh
 #endif  /* include-once blocker. */
 
 /* end of mojoshader.h ... */
-

--- a/mojoshader.h
+++ b/mojoshader.h
@@ -4362,3 +4362,4 @@ DECLSPEC unsigned int MOJOSHADER_sdlGetSamplerSlots(MOJOSHADER_sdlShaderData *sh
 #endif  /* include-once blocker. */
 
 /* end of mojoshader.h ... */
+

--- a/mojoshader_sdlgpu.c
+++ b/mojoshader_sdlgpu.c
@@ -443,18 +443,14 @@ MOJOSHADER_sdlProgram *MOJOSHADER_sdlLinkProgram(
             {
                 uint32_t typeLoad = vTable->attrib_type_load_offsets[MOJOSHADER_USAGE_BLENDINDICES][usageIndex].load_types[j];
                 uint32_t opcodeLoad = vTable->attrib_type_load_offsets[MOJOSHADER_USAGE_BLENDINDICES][usageIndex].load_opcodes[j];
+                uint32_t *ptr_to_opcode_u32 = &((uint32_t*)vshader->parseData->output)[opcodeLoad];
                 ((uint32_t*)vshader->parseData->output)[typeLoad] = vTable->tid_uvec4;
-                ((uint32_t*)vshader->parseData->output)[opcodeLoad] = SpvOpConvertUToF;
+                *ptr_to_opcode_u32 = (*ptr_to_opcode_u32 & 0xFFFF0000) | SpvOpConvertUToF;
             }
         }
     }
 
     MOJOSHADER_spirv_link_attributes(vshader->parseData, pshader->parseData, 0);
-
-    /* debug dump the spir-v */
-    SDL_IOStream *stream = SDL_IOFromFile("mojoshader.spv", "w");
-    SDL_WriteIO(stream, vshader->parseData->output, vshader->parseData->output_len - sizeof(SpirvPatchTable));
-    SDL_CloseIO(stream);
 
     SDL_zero(createInfo);
     createInfo.code = (const Uint8*) vshader->parseData->output;

--- a/mojoshader_sdlgpu.c
+++ b/mojoshader_sdlgpu.c
@@ -439,10 +439,10 @@ MOJOSHADER_sdlProgram *MOJOSHADER_sdlLinkProgram(
         if (element->usage == MOJOSHADER_USAGE_BLENDINDICES) {
             uint32_t typeDecl = vTable->attrib_type_offsets[MOJOSHADER_USAGE_BLENDINDICES][usageIndex];
             ((uint32_t*)vshader->parseData->output)[typeDecl] = vTable->tid_uvec4_p;
-            for (uint32_t i = 0; i < vTable->attrib_type_load_offsets[MOJOSHADER_USAGE_BLENDINDICES][usageIndex].num_loads; i += 1)
+            for (uint32_t j = 0; j < vTable->attrib_type_load_offsets[MOJOSHADER_USAGE_BLENDINDICES][usageIndex].num_loads; j += 1)
             {
-                uint32_t typeLoad = vTable->attrib_type_load_offsets[MOJOSHADER_USAGE_BLENDINDICES][usageIndex].load_types[i];
-                uint32_t opcodeLoad = vTable->attrib_type_load_offsets[MOJOSHADER_USAGE_BLENDINDICES][usageIndex].load_opcodes[i];
+                uint32_t typeLoad = vTable->attrib_type_load_offsets[MOJOSHADER_USAGE_BLENDINDICES][usageIndex].load_types[j];
+                uint32_t opcodeLoad = vTable->attrib_type_load_offsets[MOJOSHADER_USAGE_BLENDINDICES][usageIndex].load_opcodes[j];
                 ((uint32_t*)vshader->parseData->output)[typeLoad] = vTable->tid_uvec4;
                 ((uint32_t*)vshader->parseData->output)[opcodeLoad] = SpvOpConvertUToF;
             }

--- a/mojoshader_sdlgpu.c
+++ b/mojoshader_sdlgpu.c
@@ -451,6 +451,11 @@ MOJOSHADER_sdlProgram *MOJOSHADER_sdlLinkProgram(
 
     MOJOSHADER_spirv_link_attributes(vshader->parseData, pshader->parseData, 0);
 
+    /* debug dump the spir-v */
+    SDL_IOStream *stream = SDL_IOFromFile("mojoshader.spv", "w");
+    SDL_WriteIO(stream, vshader->parseData->output, vshader->parseData->output_len - sizeof(SpirvPatchTable));
+    SDL_CloseIO(stream);
+
     SDL_zero(createInfo);
     createInfo.code = (const Uint8*) vshader->parseData->output;
     createInfo.codeSize = vshader->parseData->output_len - sizeof(SpirvPatchTable);


### PR DESCRIPTION
The SDL_gpu backend needs to patch SPIR-V for non-float inputs to render correctly. 