### PR TITLE
Add point_size fixup for MSL + sdlgpu

### DIFF
--- a/mojoshader_sdlgpu.c
+++ b/mojoshader_sdlgpu.c
@@ -652,7 +652,13 @@ static MOJOSHADER_sdlProgram *compile_program(
         // Handle texcoord0 -> point_coord conversion
         if (strstr(vshaderSource, "[[point_size]]"))
         {
-            pshaderSource = strdup(pshader->parseData->output);
+            pshaderSource = (char *) ctx->malloc_fn(strlen(pshader->parseData->output) + 1, ctx->malloc_data);
+            if (!pshaderSource)
+            {
+                out_of_memory();
+                return NULL;
+            }
+            strcpy(pshaderSource, pshader->parseData->output);
 
             // !!! FIXME: This assumes all texcoord0 attributes in the effect are
             // !!! FIXME:  actually point coords! It ain't necessarily so! -caleb
@@ -667,7 +673,7 @@ static MOJOSHADER_sdlProgram *compile_program(
                 while (spaces < 2)
                     if (*(ptr--) == ' ')
                         spaces++;
-                memcpy(ptr, "2", sizeof(char));
+                *ptr = '2';
             } // while
         } // if
     }
@@ -712,6 +718,9 @@ static MOJOSHADER_sdlProgram *compile_program(
         ctx->free_fn(program, ctx->malloc_data);
         return NULL;
     } // if
+
+    if (pshaderSource != pshader->parseData->output)
+        ctx->free_fn(ctx, pshaderSource);
 
     return program;
 } // compile_program

--- a/mojoshader_sdlgpu.c
+++ b/mojoshader_sdlgpu.c
@@ -720,7 +720,7 @@ static MOJOSHADER_sdlProgram *compile_program(
     } // if
 
     if (pshaderSource != pshader->parseData->output)
-        ctx->free_fn(ctx, pshaderSource);
+        ctx->free_fn(pshaderSource, ctx->malloc_data);
 
     return program;
 } // compile_program

--- a/mojoshader_sdlgpu.c
+++ b/mojoshader_sdlgpu.c
@@ -597,6 +597,8 @@ static MOJOSHADER_sdlProgram *compile_program(
         return NULL;
     } // if
 
+    const char *vshaderSource = vshader->parseData->output;
+    const char *pshaderSource = pshader->parseData->output;
     size_t vshaderCodeSize = vshader->parseData->output_len;
     size_t pshaderCodeSize = pshader->parseData->output_len;
 
@@ -645,9 +647,33 @@ static MOJOSHADER_sdlProgram *compile_program(
         vshaderCodeSize -= sizeof(SpirvPatchTable);
         pshaderCodeSize -= sizeof(SpirvPatchTable);
     }
+    else if (shader_format == SDL_GPU_SHADERFORMAT_MSL)
+    {
+        // Handle texcoord0 -> point_coord conversion
+        if (strstr(vshaderSource, "[[point_size]]"))
+        {
+            pshaderSource = strdup(pshader->parseData->output);
+
+            // !!! FIXME: This assumes all texcoord0 attributes in the effect are
+            // !!! FIXME:  actually point coords! It ain't necessarily so! -caleb
+            const char *repl = "[[  point_coord  ]]";
+            char *ptr;
+            while ((ptr = strstr(pshaderSource, "[[user(texcoord0)]]")))
+            {
+                memcpy(ptr, repl, strlen(repl));
+
+                // "float4" -> "float2"
+                int spaces = 0;
+                while (spaces < 2)
+                    if (*(ptr--) == ' ')
+                        spaces++;
+                memcpy(ptr, "2", sizeof(char));
+            } // while
+        } // if
+    }
 
     SDL_zero(createInfo);
-    createInfo.code = (const Uint8*) vshader->parseData->output;
+    createInfo.code = (const Uint8*) vshaderSource;
     createInfo.code_size = vshaderCodeSize;
     createInfo.entrypoint = vshader->parseData->mainfn;
     createInfo.format = shader_format;
@@ -667,7 +693,7 @@ static MOJOSHADER_sdlProgram *compile_program(
         return NULL;
     } // if
 
-    createInfo.code = (const Uint8*) pshader->parseData->output;
+    createInfo.code = (const Uint8*) pshaderSource;
     createInfo.code_size = pshaderCodeSize;
     createInfo.entrypoint = pshader->parseData->mainfn;
     createInfo.format = shader_format;


### PR DESCRIPTION
Ported over the old Metal [`[[point_size]]` fixup logic](https://github.com/icculus/mojoshader/blob/32ae391c33f4298703989dedd72799df9a6a149b/mojoshader_metal.c#L300) for the MSL path in the SDL_GPU backend. This gets Flotilla running on FNA3D + SDLGPU + Metal!