### PR TITLE
Add missing null-terminator on file macro definition string

### DIFF
--- a/mojoshader_preprocessor.c
+++ b/mojoshader_preprocessor.c
@@ -451,12 +451,13 @@ static const Define *find_define(Context *ctx, const char *sym)
         const IncludeState *state = ctx->include_stack;
         const char *fname = state ? state->filename : "";
         const size_t len = strlen(fname) + 2;
-        char *str = (char *) Malloc(ctx, len);
+        char *str = (char *) Malloc(ctx, len + 1);
         if (!str)
             return NULL;
         str[0] = '\"';
         memcpy(str + 1, fname, len - 2);
         str[len - 1] = '\"';
+        str[len] = '\0';
         ctx->file_macro->definition = str;
         return ctx->file_macro;
     } // if


### PR DESCRIPTION
Avoids potential buffer overflow in subsequent reads.

To reproduce in the unpatched version, try
```
#pragma file __FILE__
```
somewhere in *source* passed to `MOJOSHADER_preprocess()`.

Stack-trace from AddressSanitizer:
```
Heap-buffer-overflow on address 0x50200000273b at pc 0x62c95b88a117 bp 0x7ffcefe56af0 sp 0x7ffcefe562b8
READ of size 12 at 0x50200000273b thread T0
  at 0x62c95b88a116 strlen
  at 0x62c95c37d6fc handle_pp_identifier (mojoshader_preprocessor.c:1547)
  at 0x62c95c378320 _preprocessor_nexttoken (mojoshader_preprocessor.c:2133)
  at 0x62c95c377ca4 preprocessor_nexttoken (mojoshader_preprocessor.c:2173)
  at 0x62c95c378a64 MOJOSHADER_preprocess (mojoshader_preprocessor.c:2268)
  ...
  at 0x62c95b872224 _start
Allocated by thread T0 here:
  at 0x62c95b912053 malloc
  at 0x62c95c3841da MOJOSHADER_internal_malloc (mojoshader_common.c:12)
  at 0x62c95c379529 Malloc (mojoshader_preprocessor.c:73)
  at 0x62c95c37e54e find_define (mojoshader_preprocessor.c:454)
  at 0x62c95c37d62b handle_pp_identifier (mojoshader_preprocessor.c:1541)
  at 0x62c95c378320 _preprocessor_nexttoken (mojoshader_preprocessor.c:2133)
  at 0x62c95c377ca4 preprocessor_nexttoken (mojoshader_preprocessor.c:2173)
  at 0x62c95c378a64 MOJOSHADER_preprocess (mojoshader_preprocessor.c:2268)
  ...
  at 0x62c95b872224 _start
```