### PR TITLE
hlsl: Add BLENDWEIGHT case for pixel shader input

### DIFF
--- a/profiles/mojoshader_profile_hlsl.c
+++ b/profiles/mojoshader_profile_hlsl.c
@@ -1069,6 +1069,9 @@ void emit_HLSL_attribute(Context *ctx, RegisterType regtype, int regnum,
                     case MOJOSHADER_USAGE_POSITION:
                         output_line(ctx, "float4 m_%s : POSITION%d;", var, index);
                         break;
+                    case MOJOSHADER_USAGE_BLENDWEIGHT:
+                        output_line(ctx, "float4 m_%s : BLENDWEIGHT%d;", var, index);
+                        break;
                     default:
                         fail(ctx, "BUG: unhandled pixel shader input");
                         break;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the MojoShader project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

