### PR TITLE
Use "long long" in MOJOSHADER_printFloat

### DIFF
--- a/mojoshader_common.c
+++ b/mojoshader_common.c
@@ -1000,7 +1000,7 @@ size_t MOJOSHADER_printFloat(char *text, size_t maxlen, float arg)
     else if (arg)
     {
         /* This isn't especially accurate, but hey, it's easy. :) */
-        unsigned long value;
+        unsigned long long value;
 
         if (arg < 0)
         {
@@ -1012,8 +1012,8 @@ size_t MOJOSHADER_printFloat(char *text, size_t maxlen, float arg)
             ++text;
             arg = -arg;
         } // if
-        value = (unsigned long) arg;
-        len = snprintf(text, left, "%lu", value);
+        value = (unsigned long long) arg;
+        len = snprintf(text, left, "%llu", value);
         text += len;
         if (len >= left)
             left = (left < 1) ? left : 1;
@@ -1021,7 +1021,7 @@ size_t MOJOSHADER_printFloat(char *text, size_t maxlen, float arg)
             left -= len;
         arg -= value;
 
-        int mult = 10;
+        long long mult = 10;
         if (left > 1)
         {
             *text = '.';
@@ -1030,8 +1030,8 @@ size_t MOJOSHADER_printFloat(char *text, size_t maxlen, float arg)
         ++text;
         while (precision-- > 0)
         {
-            value = (unsigned long) (arg * mult);
-            len = snprintf(text, left, "%lu", value);
+            value = (unsigned long long) (arg * mult);
+            len = snprintf(text, left, "%llu", value);
             text += len;
             if (len >= left)
                 left = (left < 1) ? left : 1;


### PR DESCRIPTION
On windows, long is 32 bit instead of 64 bit, which causes overflow.

The SDL version was updated to use UInt64: https://github.com/libsdl-org/SDL/commit/38b138cd0ab3a83b248ecb3e5a18e4329586eddb

I ran into this as a problem when a game running in proton over FNA tried to print a float with the raw hex content: `0x4f9d6700`. This resulted in the error `BUG: internal buffer is too small`, because the returned length was 103, beyond the 32 bytes that are usually used. The buffer was filled with `2147483648.21474836482147483648`. I tried to pull out the printFloat function into a simple program to reproduce this, and it didn't give the same output and didn't give a length of 103. I'm not sure of the exact reason, but UBSAN identifies an overflow on `mult *= 10;`.

With this patch, the `BUG: internal buffer is too small` crash and the UBSAN error goes away, at least for the input used in the game I was testing.

- [x] I confirm that I am the author of this code and release it to the MojoShader project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

